### PR TITLE
Feat/help and support

### DIFF
--- a/api/v1/models/__init__.py
+++ b/api/v1/models/__init__.py
@@ -4,9 +4,12 @@ Models package – import all models here so Alembic autogenerate can detect the
 
 from api.v1.models.base_model import BaseTableModel
 from api.v1.models.users import User
+from api.v1.models.support_ticket import SupportTicket
 
 
 __all__ = [
     "BaseTableModel",
     "User",
+    "SupportTicket"
 ]
+

--- a/api/v1/models/support_ticket.py
+++ b/api/v1/models/support_ticket.py
@@ -1,0 +1,24 @@
+"""
+Support Ticket Model
+File: api/v1/models/support_ticket.py
+"""
+
+from sqlalchemy import Column, String, Text, ForeignKey
+from sqlalchemy.orm import relationship
+from api.v1.models.base_model import BaseTableModel
+
+
+class SupportTicket(BaseTableModel):
+    __tablename__ = "support_tickets"
+
+    user_id = Column(String, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    subject = Column(String(255), nullable=False)
+    category = Column(String(100), nullable=False)
+    message = Column(Text, nullable=False)
+    status = Column(String(50), nullable=False, default="open")
+    # status values: "open" | "in_progress" | "resolved"
+
+    user = relationship("User", backref="support_tickets")
+
+    def __repr__(self) -> str:
+        return f"<SupportTicket id={self.id} user_id={self.user_id} status={self.status}>"

--- a/api/v1/models/users.py
+++ b/api/v1/models/users.py
@@ -1,12 +1,10 @@
-"""User Model"""
+"""User Model - api/v1/models/users.py"""
 
 from sqlalchemy import Boolean, Column, String, DateTime, Text
 from api.v1.models.base_model import BaseTableModel
 
 
 class User(BaseTableModel):
-    """SQLAlchemy User model"""
-
     __tablename__ = "users"
 
     first_name = Column(String(100), nullable=False)
@@ -18,10 +16,11 @@ class User(BaseTableModel):
     is_verified = Column(Boolean, default=False, nullable=False)
     role = Column(String(50), default="user", nullable=False)
 
-    # Hashed refresh token stored in DB (never raw)
-    hashed_refresh_token = Column(Text, nullable=True)
+    # NEW: account management fields
+    phone_number = Column(String(20), nullable=True)
+    avatar_url = Column(Text, nullable=True)
 
-    # Hashed password-reset token + expiry
+    hashed_refresh_token = Column(Text, nullable=True)
     hashed_reset_token = Column(Text, nullable=True)
     reset_token_expires_at = Column(DateTime(timezone=True), nullable=True)
 

--- a/api/v1/routes/__init__.py
+++ b/api/v1/routes/__init__.py
@@ -7,8 +7,12 @@ from fastapi import APIRouter
 
 from api.v1.routes.auth_route import auth
 
+from api.v1.routes.users import users  
+
 
 api_version_one = APIRouter(prefix="/api/v1")
 
 
 api_version_one.include_router(auth)
+
+api_version_one.include_router(users)

--- a/api/v1/routes/__init__.py
+++ b/api/v1/routes/__init__.py
@@ -1,18 +1,18 @@
 """
-Routes Registration
+API v1 Router
 File: api/v1/routes/__init__.py
 
+Registers all feature routers under /api/v1
 """
+
 from fastapi import APIRouter
 
 from api.v1.routes.auth_route import auth
-
-from api.v1.routes.users import users  
-
+from api.v1.routes.users import users
+from api.v1.routes.support import support
 
 api_version_one = APIRouter(prefix="/api/v1")
 
-
 api_version_one.include_router(auth)
-
 api_version_one.include_router(users)
+api_version_one.include_router(support)

--- a/api/v1/routes/auth_route.py
+++ b/api/v1/routes/auth_route.py
@@ -10,6 +10,7 @@ from api.db.database import get_db
 from api.utils.jwt_handler import get_current_user
 from api.utils.success_response import success_response
 from api.v1.models.users import User
+from api.v1.schemas.users import UserProfileResponse
 from api.v1.schemas.auth import (
     ForgotPasswordRequest,
     LogoutRequest,
@@ -143,7 +144,7 @@ async def get_me(
     """
     Returns the profile of the currently authenticated user.
     """
-    user_data = UserResponse.model_validate(current_user).model_dump()
+    user_data = UserProfileResponse.model_validate(current_user).model_dump()
     return success_response(
         status_code=status.HTTP_200_OK,
         message="User profile retrieved successfully.",

--- a/api/v1/routes/support.py
+++ b/api/v1/routes/support.py
@@ -1,0 +1,107 @@
+"""
+Support Router
+File: api/v1/routes/support.py
+
+Endpoints:
+  POST /support/ticket          – submit a new support ticket
+  GET  /support/tickets         – list own tickets (admin: all tickets)
+  GET  /support/ticket/{id}     – get a single ticket by ID
+"""
+
+from fastapi import APIRouter, Depends, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.db.database import get_db
+from api.utils.jwt_handler import get_current_user
+from api.utils.success_response import success_response
+from api.v1.models.users import User
+from api.v1.schemas.support import CreateTicketRequest, TicketResponse, TicketListResponse
+from api.v1.services.support import support_service
+
+
+support = APIRouter(prefix="/support", tags=["Support"])
+
+
+# ---------------------------------------------------------------------------
+# POST /support/ticket — Submit a new ticket
+# ---------------------------------------------------------------------------
+
+@support.post(
+    "/ticket",
+    status_code=status.HTTP_201_CREATED,
+    summary="Submit a new support ticket",
+    response_model=None,
+)
+async def create_ticket(
+    schema: CreateTicketRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Create a new support ticket for the authenticated user.
+    Status is set to 'open' automatically.
+    """
+    ticket = await support_service.create_ticket(
+        schema=schema, user=current_user, db=db
+    )
+    return success_response(
+        status_code=status.HTTP_201_CREATED,
+        message="Your support ticket has been submitted. We'll get back to you shortly.",
+        data=TicketResponse.model_validate(ticket).model_dump(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /support/tickets — List tickets
+# ---------------------------------------------------------------------------
+
+@support.get(
+    "/tickets",
+    status_code=status.HTTP_200_OK,
+    summary="List support tickets (own for user, all for admin)",
+    response_model=None,
+)
+async def get_tickets(
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Returns all support tickets belonging to the current user.
+    Admin users receive all tickets across the platform.
+    """
+    tickets = await support_service.get_tickets(user=current_user, db=db)
+    ticket_data = [TicketResponse.model_validate(t).model_dump() for t in tickets]
+    return success_response(
+        status_code=status.HTTP_200_OK,
+        message="Tickets retrieved successfully.",
+        data={"total": len(ticket_data), "tickets": ticket_data},
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /support/ticket/{id} — Get single ticket
+# ---------------------------------------------------------------------------
+
+@support.get(
+    "/ticket/{ticket_id}",
+    status_code=status.HTTP_200_OK,
+    summary="Get a single support ticket by ID",
+    response_model=None,
+)
+async def get_ticket(
+    ticket_id: str,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Returns a single ticket. Returns 403 if the ticket belongs to a different user.
+    Admin users can access any ticket.
+    """
+    ticket = await support_service.get_ticket(
+        ticket_id=ticket_id, user=current_user, db=db
+    )
+    return success_response(
+        status_code=status.HTTP_200_OK,
+        message="Ticket retrieved successfully.",
+        data=TicketResponse.model_validate(ticket).model_dump(),
+    )

--- a/api/v1/routes/users.py
+++ b/api/v1/routes/users.py
@@ -1,0 +1,138 @@
+"""
+Users Router
+File: api/v1/routes/users.py
+
+Endpoints for user account management:
+  GET  /users/me              – fetch current user profile
+  PUT  /users/update          – update profile fields
+  PUT  /users/change-password – change password
+  POST /users/upload-avatar   – upload profile picture
+"""
+
+from fastapi import APIRouter, Depends, File, UploadFile, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.db.database import get_db
+from api.utils.jwt_handler import get_current_user
+from api.utils.success_response import success_response
+from api.v1.models.users import User
+from api.v1.schemas.users import (
+    ChangePasswordRequest,
+    UpdateProfileRequest,
+    UserProfileResponse,
+)
+from api.v1.services.users import user_service
+
+
+users = APIRouter(prefix="/users", tags=["Users"])
+
+
+# ---------------------------------------------------------------------------
+# GET /users/me
+# ---------------------------------------------------------------------------
+
+@users.get(
+    "/me",
+    status_code=status.HTTP_200_OK,
+    summary="Get current user profile",
+    response_model=None,
+)
+async def get_profile(
+    current_user: User = Depends(get_current_user),
+):
+    """
+    Returns the full profile of the currently authenticated user,
+    including phone_number and avatar_url.
+    """
+    profile = user_service.get_profile(current_user)
+    return success_response(
+        status_code=status.HTTP_200_OK,
+        message="Profile retrieved successfully.",
+        data=UserProfileResponse.model_validate(profile).model_dump(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# PUT /users/update
+# ---------------------------------------------------------------------------
+
+@users.put(
+    "/update",
+    status_code=status.HTTP_200_OK,
+    summary="Update user profile fields",
+    response_model=None,
+)
+async def update_profile(
+    schema: UpdateProfileRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Update one or more profile fields: first_name, last_name, username,
+    phone_number. Only provided fields are updated (partial update).
+    """
+    updated_user = await user_service.update_profile(
+        schema=schema, user=current_user, db=db
+    )
+    return success_response(
+        status_code=status.HTTP_200_OK,
+        message="Profile updated successfully.",
+        data=UserProfileResponse.model_validate(updated_user).model_dump(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# PUT /users/change-password
+# ---------------------------------------------------------------------------
+
+@users.put(
+    "/change-password",
+    status_code=status.HTTP_200_OK,
+    summary="Change authenticated user password",
+    response_model=None,
+)
+async def change_password(
+    schema: ChangePasswordRequest,
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Verify current_password, then hash and store new_password.
+    All existing sessions are invalidated on success.
+    """
+    await user_service.change_password(
+        schema=schema, user=current_user, db=db
+    )
+    return success_response(
+        status_code=status.HTTP_200_OK,
+        message="Password changed successfully. Please log in again.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /users/upload-avatar
+# ---------------------------------------------------------------------------
+
+@users.post(
+    "/upload-avatar",
+    status_code=status.HTTP_200_OK,
+    summary="Upload or replace profile avatar",
+    response_model=None,
+)
+async def upload_avatar(
+    file: UploadFile = File(..., description="Image file: jpg, jpeg, png, webp. Max 5MB."),
+    current_user: User = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Upload a profile avatar image. Accepted formats: jpg, jpeg, png, webp.
+    Maximum file size: 5MB. Returns the updated user profile with the new avatar_url.
+    """
+    updated_user = await user_service.upload_avatar(
+        file=file, user=current_user, db=db
+    )
+    return success_response(
+        status_code=status.HTTP_200_OK,
+        message="Avatar uploaded successfully.",
+        data=UserProfileResponse.model_validate(updated_user).model_dump(),
+    )

--- a/api/v1/schemas/support.py
+++ b/api/v1/schemas/support.py
@@ -1,0 +1,73 @@
+"""
+Support Ticket Pydantic Schemas
+File: api/v1/schemas/support.py
+"""
+
+from datetime import datetime
+from typing import List, Optional
+from pydantic import BaseModel, Field, field_validator
+
+# Valid ticket categories
+VALID_CATEGORIES = {
+    "Booking Issue",
+    "Payment Issue",
+    "Account Issue",
+    "Other",
+}
+
+
+# ---------------------------------------------------------------------------
+# Request
+# ---------------------------------------------------------------------------
+
+class CreateTicketRequest(BaseModel):
+    """Schema for submitting a new support ticket."""
+
+    subject: str = Field(..., min_length=3, max_length=255, description="Brief summary of the issue")
+    category: str = Field(..., description="One of: Booking Issue, Payment Issue, Account Issue, Other")
+    message: str = Field(..., min_length=10, max_length=5000, description="Full description of the issue")
+
+    @field_validator("subject")
+    @classmethod
+    def strip_subject(cls, v: str) -> str:
+        return v.strip()
+
+    @field_validator("category")
+    @classmethod
+    def validate_category(cls, v: str) -> str:
+        if v not in VALID_CATEGORIES:
+            raise ValueError(
+                f"Invalid category. Must be one of: {', '.join(sorted(VALID_CATEGORIES))}"
+            )
+        return v
+
+    @field_validator("message")
+    @classmethod
+    def strip_message(cls, v: str) -> str:
+        return v.strip()
+
+
+# ---------------------------------------------------------------------------
+# Response
+# ---------------------------------------------------------------------------
+
+class TicketResponse(BaseModel):
+    """Full ticket object returned in API responses."""
+
+    id: str
+    user_id: str
+    subject: str
+    category: str
+    message: str
+    status: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class TicketListResponse(BaseModel):
+    """Wrapper for a list of tickets with a total count."""
+
+    total: int
+    tickets: List[TicketResponse]

--- a/api/v1/schemas/users.py
+++ b/api/v1/schemas/users.py
@@ -1,0 +1,99 @@
+"""
+User Pydantic Schemas
+File: api/v1/schemas/users.py
+"""
+
+import re
+from typing import Optional
+from datetime import datetime
+
+from pydantic import BaseModel, EmailStr, Field, field_validator
+
+
+# ---------------------------------------------------------------------------
+# Update Profile
+# ---------------------------------------------------------------------------
+
+class UpdateProfileRequest(BaseModel):
+    """Schema for updating user profile fields. All fields are optional."""
+
+    first_name: Optional[str] = Field(None, min_length=1, max_length=100)
+    last_name: Optional[str] = Field(None, min_length=1, max_length=100)
+    username: Optional[str] = Field(None, min_length=3, max_length=100)
+    email: Optional[EmailStr] = Field(None)
+    phone_number: Optional[str] = Field(None, max_length=20)
+
+    @field_validator("username")
+    @classmethod
+    def validate_username(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        if not re.match(r"^[a-zA-Z0-9_]+$", v):
+            raise ValueError(
+                "Username may only contain letters, digits, and underscores."
+            )
+        return v.lower()
+
+    @field_validator("phone_number")
+    @classmethod
+    def validate_phone_number(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        cleaned = v.strip().replace(" ", "").replace("-", "")
+        if not re.match(r"^\+?[1-9]\d{6,14}$", cleaned):
+            raise ValueError("Invalid phone number format.")
+        return cleaned
+
+    @field_validator("first_name", "last_name")
+    @classmethod
+    def strip_names(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        return v.strip()
+
+
+# ---------------------------------------------------------------------------
+# Change Password
+# ---------------------------------------------------------------------------
+
+class ChangePasswordRequest(BaseModel):
+    """Schema for changing the authenticated user's password."""
+
+    current_password: str = Field(..., min_length=1)
+    new_password: str = Field(..., min_length=8, max_length=128)
+
+    @field_validator("new_password")
+    @classmethod
+    def validate_password_strength(cls, v: str) -> str:
+        if not re.search(r"[A-Z]", v):
+            raise ValueError("Password must contain at least one uppercase letter.")
+        if not re.search(r"[a-z]", v):
+            raise ValueError("Password must contain at least one lowercase letter.")
+        if not re.search(r"\d", v):
+            raise ValueError("Password must contain at least one digit.")
+        if not re.search(r"[!@#$%^&*(),.?\":{}|<>]", v):
+            raise ValueError("Password must contain at least one special character.")
+        return v
+
+
+# ---------------------------------------------------------------------------
+# User Profile Response
+# ---------------------------------------------------------------------------
+
+class UserProfileResponse(BaseModel):
+    """Full user profile returned by /users/me and update endpoints."""
+
+    id: str
+    first_name: str
+    last_name: str
+    username: Optional[str]
+    email: str
+    phone_number: Optional[str]
+    avatar_url: Optional[str]
+    is_active: bool
+    is_verified: bool
+    role: str
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}

--- a/api/v1/services/support.py
+++ b/api/v1/services/support.py
@@ -1,0 +1,115 @@
+"""
+Support Ticket Service
+File: api/v1/services/support.py
+"""
+
+from typing import List
+
+from fastapi import HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+from sqlalchemy import desc
+
+from api.loggers.app_logger import app_logger
+from api.v1.models.support_ticket import SupportTicket
+from api.v1.models.users import User
+from api.v1.schemas.support import CreateTicketRequest
+
+
+class SupportService:
+    """Business logic for support ticket operations."""
+
+    # -----------------------------------------------------------------------
+    # Create Ticket
+    # -----------------------------------------------------------------------
+
+    async def create_ticket(
+        self, schema: CreateTicketRequest, user: User, db: AsyncSession
+    ) -> SupportTicket:
+        """
+        Create a new support ticket for the authenticated user.
+        Sets status to 'open' by default.
+        Triggers an email notification (stubbed — wire up when email service is ready).
+        """
+        ticket = SupportTicket(
+            user_id=user.id,
+            subject=schema.subject,
+            category=schema.category,
+            message=schema.message,
+            status="open",
+        )
+        db.add(ticket)
+        await db.commit()
+        await db.refresh(ticket)
+
+        app_logger.info(
+            f"Support ticket created: id={ticket.id} user_id={user.id} category={ticket.category}"
+        )
+
+        # TODO: Send email notification to support team when email service is configured
+        # await send_support_email(
+        #     to="complaints@smashapartments.com",
+        #     subject=f"New Support Ticket [{ticket.category}]: {ticket.subject}",
+        #     body=f"From: {user.email}\n\n{ticket.message}",
+        # )
+
+        return ticket
+
+    # -----------------------------------------------------------------------
+    # Get All Tickets (own for user, all for admin)
+    # -----------------------------------------------------------------------
+
+    async def get_tickets(
+        self, user: User, db: AsyncSession
+    ) -> List[SupportTicket]:
+        """
+        Return tickets for the current user.
+        If the user has role 'admin', return all tickets across all users.
+        Results are ordered newest first.
+        """
+        if user.role == "admin":
+            result = await db.execute(
+                select(SupportTicket).order_by(desc(SupportTicket.created_at))
+            )
+        else:
+            result = await db.execute(
+                select(SupportTicket)
+                .filter(SupportTicket.user_id == user.id)
+                .order_by(desc(SupportTicket.created_at))
+            )
+
+        return result.scalars().all()
+
+    # -----------------------------------------------------------------------
+    # Get Single Ticket
+    # -----------------------------------------------------------------------
+
+    async def get_ticket(
+        self, ticket_id: str, user: User, db: AsyncSession
+    ) -> SupportTicket:
+        """
+        Return a single ticket by ID.
+        Raises 404 if not found.
+        Raises 403 if the ticket belongs to another user (unless admin).
+        """
+        result = await db.execute(
+            select(SupportTicket).filter(SupportTicket.id == ticket_id)
+        )
+        ticket = result.scalars().first()
+
+        if not ticket:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Support ticket not found.",
+            )
+
+        if user.role != "admin" and ticket.user_id != user.id:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have permission to view this ticket.",
+            )
+
+        return ticket
+
+
+support_service = SupportService()

--- a/api/v1/services/users.py
+++ b/api/v1/services/users.py
@@ -1,0 +1,173 @@
+"""
+User Service
+File: api/v1/services/users.py
+"""
+
+import base64
+
+from fastapi import HTTPException, UploadFile, status
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.future import select
+
+from api.loggers.app_logger import app_logger
+from api.utils.jwt_handler import hash_password, verify_password
+from api.v1.models.users import User
+from api.v1.schemas.users import ChangePasswordRequest, UpdateProfileRequest
+
+
+AVATAR_ALLOWED_EXTENSIONS = ["jpg", "jpeg", "png", "webp"]
+AVATAR_MAX_SIZE_MB = 5
+
+
+class UserService:
+
+    # -----------------------------------------------------------------------
+    # Get Profile
+    # -----------------------------------------------------------------------
+
+    def get_profile(self, user: User) -> User:
+        """Return user already loaded by JWT dependency — no extra DB call needed."""
+        return user
+
+    # -----------------------------------------------------------------------
+    # Update Profile
+    # -----------------------------------------------------------------------
+
+    async def update_profile(
+        self, schema: UpdateProfileRequest, user: User, db: AsyncSession
+    ) -> User:
+        """
+        Partial update — only fields explicitly sent are written to DB.
+
+        Raises:
+            HTTPException 409 – if new username is already taken.
+        """
+        if schema.username and schema.username != user.username:
+            result = await db.execute(
+                select(User).filter(
+                    User.username == schema.username,
+                    User.id != user.id,
+                )
+            )
+            if result.scalars().first():
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="This username is already taken.",
+                )
+
+        if schema.email and schema.email != user.email:
+            result = await db.execute(
+                select(User).filter(
+                    User.email == schema.email,
+                    User.id != user.id,
+                )
+            )
+            if result.scalars().first():
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="This email address is already in use.",
+                )
+
+        update_data = schema.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(user, field, value)
+
+        await db.commit()
+        await db.refresh(user)
+        app_logger.info(
+            f"Profile updated for user id={user.id} | fields={list(update_data.keys())}"
+        )
+        return user
+
+    # -----------------------------------------------------------------------
+    # Change Password
+    # -----------------------------------------------------------------------
+
+    async def change_password(
+        self, schema: ChangePasswordRequest, user: User, db: AsyncSession
+    ) -> None:
+        """
+        Verify current password then store new bcrypt hash.
+        Invalidates all existing sessions.
+
+        Raises:
+            HTTPException 401 – if current password is wrong.
+            HTTPException 400 – if new password is same as current.
+        """
+        if not verify_password(schema.current_password, user.hashed_password):
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Current password is incorrect.",
+            )
+
+        if verify_password(schema.new_password, user.hashed_password):
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="New password must differ from the current password.",
+            )
+
+        user.hashed_password = hash_password(schema.new_password)
+        user.hashed_refresh_token = None  # Invalidate all sessions
+        await db.commit()
+        app_logger.info(f"Password changed for user id={user.id}")
+
+    # -----------------------------------------------------------------------
+    # Upload Avatar — Base64 (no MinIO required)
+    # -----------------------------------------------------------------------
+
+    async def upload_avatar(
+        self, file: UploadFile, user: User, db: AsyncSession
+    ) -> User:
+        """
+        Validate the image, encode as Base64, and save directly to avatar_url.
+
+        No external storage service needed. The Base64 data URL works
+        natively as an <img src> value in any browser.
+
+        NOTE: When MinIO is available, replace the base64 block below
+        with minio_service.upload_to_minio() — no other changes needed.
+
+        Raises:
+            HTTPException 400 – invalid file format or exceeds size limit.
+        """
+        # Validate extension
+        file_ext = file.filename.split(".")[-1].lower() if file.filename else ""
+        if file_ext not in AVATAR_ALLOWED_EXTENSIONS:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"Invalid file format. Allowed: {', '.join(AVATAR_ALLOWED_EXTENSIONS)}",
+            )
+
+        # Read file bytes
+        content = await file.read()
+
+        # Validate file size
+        size_mb = len(content) / (1024 * 1024)
+        if size_mb > AVATAR_MAX_SIZE_MB:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"File too large. Maximum size is {AVATAR_MAX_SIZE_MB}MB.",
+            )
+
+        # Encode to Base64 data URL
+        mime_map = {
+            "jpg": "image/jpeg",
+            "jpeg": "image/jpeg",
+            "png": "image/png",
+            "webp": "image/webp",
+        }
+        mime_type = mime_map.get(file_ext, "image/jpeg")
+        base64_str = base64.b64encode(content).decode("utf-8")
+        data_url = f"data:{mime_type};base64,{base64_str}"
+
+        # Persist to DB
+        user.avatar_url = data_url
+        await db.commit()
+        await db.refresh(user)
+
+        app_logger.info(f"Avatar uploaded (base64) for user id={user.id}")
+        return user
+
+
+# Singleton
+user_service = UserService()

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ Jinja2==3.1.6
 Mako==1.3.10
 MarkupSafe==3.0.3
 pandas==2.3.3
+numpy<2
 psycopg2-binary==2.9.11
 pyasn1==0.6.1
 pydantic==2.12.4
@@ -26,6 +27,7 @@ python-jose==3.5.0
 pytz==2025.2
 rsa==4.9.1
 six==1.17.0
+opencv-python==4.8.1.78
 sniffio==1.3.1
 SQLAlchemy==2.0.44
 starlette==0.50.0
@@ -40,6 +42,7 @@ pytest==7.4.3
 pytest-asyncio==0.21.1
 httpx==0.25.2
 firebase-admin==6.2.0
+minio==7.2.0
 # passlib[bcrypt]==1.7.4
 python-multipart==0.0.6
 passlib==1.7.4


### PR DESCRIPTION
## Summary
Implements the Help & Support section of the Smash Apartments dashboard.
Both `/customer-support` and `/helpful` previously resolved to 404 — 
both are now fully functional.

## Backend (be-apartment)
- New `SupportTicket` model with fields: `user_id`, `subject`, `category`, `message`, `status`
- Alembic migration creating the `support_tickets` table
- New endpoints under `/api/v1/support/`:
  - `POST /ticket` — creates a ticket with status `open`, JWT protected
  - `GET /tickets` — returns own tickets; admin role returns all tickets
  - `GET /ticket/{id}` — returns single ticket, enforces ownership (403 for unauthorized access)
- Router registered in `api/v1/routes/__init__.py`
- Email notification stubbed with `TODO` — ready to wire up when email service is configured

## Frontend (apartment)
- `CustomerSupport.jsx` — ticket submission form with category dropdown, subject, and message fields; full validation; success toast on submission; ticket history with status badges (open/in-progress/resolved), skeleton loader, and empty state
- `HelpfulArticles.jsx` — FAQ accordion across 5 categories (Bookings, Payments, Account & Profile, Stays, Car Rentals); one item open at a time; "Contact Support" CTA linking back to `/customer-support`
- `App.jsx` — routes `/customer-support` and `/helpful` registered
- Both pages match existing design system — same layout, breadcrumb, sidebar, and footer pattern as `PersonalDetails.jsx`

## Notes
- This branch was created from `feat/account-management` — merge that branch first before merging this one
- Email notification is stubbed in `services/support.py` — replace the `TODO` block with `send_support_email()` when the email utility is ready
- Ticket status updates (`in_progress`, `resolved`) are admin operations — to be handled in a future admin dashboard task